### PR TITLE
v3.0.2: fix "XBMC is not playing any media file" when skipping beyond end of file

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.1" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
+<addon id="script.xbmc.unpausejumpback" name="Unpause Jumpback" version="3.0.2" provider-name="bossanova808,Memphiz,Lucleonhart,schumi2004,dkadioglu">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -22,10 +22,13 @@
     <license>GPL-3.0-only</license>
     <website>https://github.com/bossanova808/script.xbmc.unpausejumpback/</website>
     <source>https://github.com/bossanova808/script.xbmc.unpausejumpback/</source>
-    <forum>http://forum.xbmc.org/showthread.php?tid=134837</forum>
+    <forum>https://forum.kodi.tv/showthread.php?tid=355778</forum>
     <email>bossonav808@gmail.com</email>
-    <news>v3.0.1
+    <news>v3.0.2
+        - fix "XBMC is not playing any media file" when skipping beyond end of file
+        v3.0.1
         [fix] minor bugfix for http/s sources (plugins)
+        - Update for changes to Kodi Matrix logging functions
         v3.0.0
         [new] Update for Kodi Matrix / Python 3, make unpause on resume vs. pause a choice, bugfixes and tidy up.
     </news>

--- a/addon.xml
+++ b/addon.xml
@@ -25,10 +25,10 @@
     <forum>https://forum.kodi.tv/showthread.php?tid=355778</forum>
     <email>bossonav808@gmail.com</email>
     <news>v3.0.2
-        - fix "XBMC is not playing any media file" when skipping beyond end of file
+        [fix] "XBMC is not playing any media file" errors
         v3.0.1
         [fix] minor bugfix for http/s sources (plugins)
-        - Update for changes to Kodi Matrix logging functions
+        [fix] Update for changes to Kodi Matrix logging functions
         v3.0.0
         [new] Update for Kodi Matrix / Python 3, make unpause on resume vs. pause a choice, bugfixes and tidy up.
     </news>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
+3.0.2
+- fix "XBMC is not playing any media file" when skipping beyond end of file
+
 3.0.1
 - Minor bugfix with http/s sources (plugins)
+- Changes for Kodi Matrix logging (LOGNOTICE -> LOGINFO)
 
 3.0.0
 - Update for Matrix / Python3 (work borrowed from https://github.com/dkadioglu/script.xbmc.unpausejumpback)

--- a/resources/lib/unpause_jumpback.py
+++ b/resources/lib/unpause_jumpback.py
@@ -194,7 +194,10 @@ class MyPlayer(xbmc.Player):
 
         # If the addon is set to do a jump back when playback is started from a resume point...
         if self.jump_back_on_playback_started:
-            current_time = self.getTime()
+            try:
+                current_time = self.getTime()
+            except:
+                current_time = 0
             log(f'onAVStarted at {current_time}')
 
             # check for exclusion

--- a/resources/lib/unpause_jumpback.py
+++ b/resources/lib/unpause_jumpback.py
@@ -216,7 +216,8 @@ class MyPlayer(xbmc.Player):
             direction = 1
             abs_last_speed = abs(self.last_playback_speed)
             # default value, just in case
-            resume_time = self.getTime()
+            if self.isPlayingVideo():
+                resume_time = self.getTime()
             if self.last_playback_speed < 0:
                 log('Resuming. Was rewound with speed X%d.' % (abs(self.last_playback_speed)))
             if self.last_playback_speed > 1:

--- a/resources/lib/unpause_jumpback.py
+++ b/resources/lib/unpause_jumpback.py
@@ -196,8 +196,10 @@ class MyPlayer(xbmc.Player):
         if self.jump_back_on_playback_started:
             try:
                 current_time = self.getTime()
-            except:
-                current_time = 0
+            except RuntimeError as exc:
+                log('No file is playing, stopping UnpauseJumpBack')
+                xbmc.executebuiltin('CancelAlarm(JumpbackPaused, true)')
+                pass
             log(f'onAVStarted at {current_time}')
 
             # check for exclusion
@@ -221,9 +223,10 @@ class MyPlayer(xbmc.Player):
             # default value, just in case
             try:
                 resume_time = self.getTime()
-            except:
-                #catch unlucky timing when not playing media any longer
-                resume_time = 0
+            except RuntimeError as exc:
+                log('No file is playing, stopping UnpauseJumpBack')
+                xbmc.executebuiltin('CancelAlarm(JumpbackPaused, true)')
+                pass
             if self.last_playback_speed < 0:
                 log('Resuming. Was rewound with speed X%d.' % (abs(self.last_playback_speed)))
             if self.last_playback_speed > 1:

--- a/resources/lib/unpause_jumpback.py
+++ b/resources/lib/unpause_jumpback.py
@@ -216,8 +216,11 @@ class MyPlayer(xbmc.Player):
             direction = 1
             abs_last_speed = abs(self.last_playback_speed)
             # default value, just in case
-            if self.isPlayingVideo():
+            try:
                 resume_time = self.getTime()
+            except:
+                #catch unlucky timing when not playing media any longer
+                resume_time = 0
             if self.last_playback_speed < 0:
                 log('Resuming. Was rewound with speed X%d.' % (abs(self.last_playback_speed)))
             if self.last_playback_speed > 1:


### PR DESCRIPTION
fixes error:
```
2020-12-09 22:58:08.529 T:1159    ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'RuntimeError'>
                                                   Error Contents: XBMC is not playing any media file
                                                   Traceback (most recent call last):
                                                     File "/home/kodi/.kodi/addons/script.xbmc.unpausejumpback/resources/lib/unpause_jumpback.py", line 219, in onPlayBackSpeedChanged
                                                       resume_time = self.getTime()
                                                   RuntimeError: XBMC is not playing any media file
                                                   -->End of Python script error report<--
```
